### PR TITLE
Fixed bug

### DIFF
--- a/src/main/java/de/crafttogether/pvptoggle/listener/OnPlayerAttacked.java
+++ b/src/main/java/de/crafttogether/pvptoggle/listener/OnPlayerAttacked.java
@@ -50,7 +50,7 @@ public class OnPlayerAttacked implements Listener {
                 Projectile projectile = (Projectile) e.getDamager();
                 projectile.getShooter();
                 if (projectile.getType() != EntityType.SNOWBALL && projectile.getType() != EntityType.ENDER_PEARL && projectile.getType() != EntityType.EGG) {
-                    if (projectile.getShooter() instanceof Player att && e.getEntity() instanceof Player pl) {
+                    if (projectile.getShooter() instanceof Player att && e.getEntity() instanceof Player pl && att != pl) {
                         e.setCancelled(pvplistCheck(pl, att));
                     }
                 }
@@ -191,4 +191,6 @@ public class OnPlayerAttacked implements Listener {
         }
         return false;
     }
+
+
 }


### PR DESCRIPTION
Ich hab herausgefunden, dass wenn man sich selber mit einem Pfeil abschießt, der Pfeile ständig über einem bounced und den Chat zuspammt, dass man selber und "Eigener Name" kein PVP aktiviert haben.

Im größerem Maße kann das zu lags auf dem Server führen, wenn zB. mehrere Personen diesen Bug absichtlich nutzen.

Habe nur einen Check mehr eingeführt, damit das Event gecancelt wird.